### PR TITLE
Fix typo in PaymentError::NonPayable string representation

### DIFF
--- a/packages/cw-utils/src/payment.rs
+++ b/packages/cw-utils/src/payment.rs
@@ -66,7 +66,7 @@ pub enum PaymentError {
     #[error("No funds sent")]
     NoFunds {},
 
-    #[error("This message does no accept funds")]
+    #[error("This message does not accept funds")]
     NonPayable {},
 }
 


### PR DESCRIPTION
I have an app which displays the stringified error a contract throws as-is.

My projects also still rely on the 1.x branch of these crates. Could this be applied as a patch to 1.0 as well?