### PR TITLE
Removed invalid content from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,33 +14,6 @@
 
 Note: `cw2` and `controllers` have been moved from the [`cw-plus` repo](https://github.com/CosmWasm/cw-plus). Their commit history and changelog can be found in the previous repository.
 
-
-## Generating changelog
-
-To generate a changelog we decided to use
-[github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator).
-
-To install tool you need Ruby's `gem` package manager.
-
-    $ gem --user install github_changelog_generator
-
-And put `$HOME/.gem/ruby/*/bin/` into your PATH.
-
-Generating changelog file first time:
-
-    $ github_changelog_generator -u CosmWasm -p cw-plus
-
-Appending next releases could be done adding `--base` flag:
-
-    $ github_changelog_generator -u CosmWasm -p cw-plus --base CHANGELOG.md
-
-If you hit GitHub's 50 requests/hour limit, please follow
-[this](https://github.com/github-changelog-generator/github-changelog-generator#github-token) guide to create a token
-key which you can pass using `--token` flag.
-
-There's also a convenience `scripts/update_changelog.sh`, which can take a --since-tag parameter (to avoid processing
-the entire history). It can also auto-detect the latest version tag for you, with --latest-tag.
-
 ## License
 
 Licensed under [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
Removed content was just copy/pasted from other repository and is no more up-to-date.
CHANGELOG.md is currently maintained manually (now it's more efficient, less error-prone and doesn't require installing additional software).